### PR TITLE
Fix output for non-Unicode locales

### DIFF
--- a/src/Test/StrictCheck/Examples/Lists.hs
+++ b/src/Test/StrictCheck/Examples/Lists.hs
@@ -20,6 +20,12 @@ length_spec =
   Spec $ \predict _ xs ->
     predict (xs $> thunk)
 
+-- | An incorrect specification for 'length' (to test the pretty printer)
+bad_length_spec :: Spec '[[a]] Int
+bad_length_spec =
+  Spec $ \predict _ xs ->
+    predict (take 1 xs $> thunk)
+
 -- | A naive specification for 'take', which is wrong
 take_spec_too_easy :: Spec '[Int, [a]] [a]
 take_spec_too_easy =

--- a/tests/Specs.hs
+++ b/tests/Specs.hs
@@ -6,6 +6,10 @@ import Test.StrictCheck
 import Test.StrictCheck.Examples.Lists
 import Test.StrictCheck.Examples.Map
 
+import Control.Monad (when)
+import GHC.IO.Encoding (textEncodingName)
+import System.IO
+
 runSpecs :: IO ()
 runSpecs = do
   putStrLn "Checking length_spec..."
@@ -35,4 +39,11 @@ runSpecs = do
     iterSolution_spec
     iterSolutionWithKey >>= print
 
-  return ()
+  putStrLn "Checking bad_length_spec (failure is expected!)..."
+  strictCheckSpecExact bad_length_spec (length :: [Int] -> Int)
+
+  enc <- hGetEncoding stdout
+  when (fmap textEncodingName enc == Just "UTF-8") $ do
+    hSetEncoding stdout latin1
+    putStrLn "Checking bad_length_spec without Unicode output (failure is expected!)..."
+    strictCheckSpecExact bad_length_spec (length :: [Int] -> Int)


### PR DESCRIPTION
Fix #1 

The crash happens not only on Windows, but more generally on systems with non-Unicode locales. It can be reproduced by calling `hSetEncoding stdout latin1` before a failing StrictCheck test.

The fix is to check whether the encoding on `stdout` supports Unicode, and when that is not the case, to restrict the output to ASCII characters.